### PR TITLE
Add support for gzipped DMARC RUA reports

### DIFF
--- a/reportErrors.sh
+++ b/reportErrors.sh
@@ -2,6 +2,7 @@
 
 mkdir -p input 
 unzip -o "samples/*.zip" -d input/
+for f in samples/*.gz; do gunzip -c $f > input/$(basename ${f%.*}); done
 
 mkdir -p reports
 


### PR DESCRIPTION
Unfortunately `gunzip` cannot unzip to a different destination using a wildcard. Therefore you need to loop over `*.gz` files and unzip them to the standard output 🤦 
